### PR TITLE
expose multitenant http port via gateway

### DIFF
--- a/src/config/env.json
+++ b/src/config/env.json
@@ -15,6 +15,7 @@
     "JAEGER_ENDPOINT": "http://jaeger-collector:14268/api/traces",
     "KIVA_CONTROLLER": "http://kiva-controller:3011",
     "LOGGLY_LEVEL": "info",
+    "MULTITENANT": "http://multitenant:3020",
     "NCRA_CONTROLLER": "http://ncra-controller:3012",
     "PORT": 8080,
     "RATE_LIMIT_MAX": "100",

--- a/src/gateway/gateway.routes.ts
+++ b/src/gateway/gateway.routes.ts
@@ -125,6 +125,13 @@ export class GatewayRoutes {
                 path: [ '/v1/router' ],
                 target : process.env.ARIES_GUARDIANSHIP_AGENCY,
             },
+            {
+                path: [ '/v2/multitenant' ],
+                target : process.env.MULTITENANT,
+                pathRewrite: {
+                    '^/v2/multitenant': ''
+                }
+            },
         ];
     }
 


### PR DESCRIPTION
We want to expose the http port of our multitenant aca-py instance via the gateway that way external agents (eg mobile) can interact with it (note port 3020 is the http one for regular aca-py interactions and port 3021 is the admin one which we leave unexposed)
Signed-off-by: Jacob Saur <jsaur@kiva.org>