### PR TITLE
PRO-3130: No more ts-node

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
             docker network ls
             docker-compose -f docker-compose.ci.yml build --no-cache
             set -x
-            docker-compose -f docker-compose.ci.yml up -d
+            docker-compose -f docker-compose.ci.yml up --force-recreate -d
             sleep 15
             docker-compose -f docker-compose.ci.yml logs
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,7 @@ jobs:
       - run:
           name: Start docker compose and wait for readiness
           command: |
+            docker system prune -f
             docker network ls
             docker-compose -f docker-compose.ci.yml build
             set -x

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
           command: |
             docker system prune -f
             docker network ls
-            docker-compose -f docker-compose.ci.yml build
+            docker-compose -f docker-compose.ci.yml build --no-cache
             set -x
             docker-compose -f docker-compose.ci.yml up -d
             sleep 15
@@ -75,7 +75,8 @@ jobs:
       - run:
           name: Start docker compose and wait for readiness
           command: |
-            docker-compose -f docker-compose.yml build
+            docker system prune -f
+            docker-compose -f docker-compose.yml build --no-cache
             docker-compose -f docker-compose.yml up -d
             sleep 20
             docker-compose -f docker-compose.yml logs

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -14,6 +14,7 @@ FROM node:14.15.1-alpine3.12
 WORKDIR /www
 COPY --from=node_modules /tmp/node_modules ./node_modules
 COPY --from=dist /tmp/dist ./dist
+COPY --from=dist /tmp/package.json ./package.json
 RUN adduser -S app
 USER app
 CMD ["node", "dist/main.js"]

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -14,7 +14,6 @@ FROM node:14.15.1-alpine3.12
 WORKDIR /www
 COPY --from=node_modules /tmp/node_modules ./node_modules
 COPY --from=dist /tmp/dist ./dist
-COPY --from=dist /tmp/package.json ./package.json
 RUN adduser -S app
 USER app
 CMD ["node", "dist/main.js"]

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -18,7 +18,7 @@ services:
     build:
       context: ./
       dockerfile: Dockerfile.production
-    command: npm run start:debug
+    command: npm run start:prod
     image: protocol-gateway
     container_name: protocol-gateway
     working_dir: /www

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -26,8 +26,6 @@ services:
       - "8080:8080"
     expose: 
       - "8080"
-    volumes:
-      - ./:/www
     networks:
       - agency-network
     tty: true

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -18,7 +18,6 @@ services:
     build:
       context: ./
       dockerfile: Dockerfile.production
-    command: npm run start:prod
     image: protocol-gateway:latest
     container_name: protocol-gateway
     working_dir: /www

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -19,7 +19,7 @@ services:
       context: ./
       dockerfile: Dockerfile.production
     command: npm run start:prod
-    image: protocol-gateway
+    image: protocol-gateway:latest
     container_name: protocol-gateway
     working_dir: /www
     ports:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1063,12 +1063,6 @@
         "pretty-format": "^26.0.0"
       }
     },
-    "@types/json5": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
-      "dev": true
-    },
     "@types/long": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
@@ -1314,12 +1308,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
       "integrity": "sha1-HjRA6RXwsSA9I3SOeO3XubW0PlY="
-    },
-    "arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true
     },
     "argparse": {
       "version": "1.0.10",
@@ -2131,12 +2119,6 @@
         "object-assign": "^4",
         "vary": "^1"
       }
-    },
-    "create-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true
     },
     "cross-spawn": {
       "version": "6.0.5",
@@ -6992,43 +6974,6 @@
         }
       }
     },
-    "ts-node": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
-      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
-      "dev": true,
-      "requires": {
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "source-map-support": "^0.5.17",
-        "yn": "3.1.1"
-      }
-    },
-    "tsconfig-paths": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
-      "integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
-      "dev": true,
-      "requires": {
-        "@types/json5": "^0.0.29",
-        "json5": "^1.0.1",
-        "minimist": "^1.2.0",
-        "strip-bom": "^3.0.0"
-      },
-      "dependencies": {
-        "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.0"
-          }
-        }
-      }
-    },
     "tslib": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
@@ -7613,9 +7558,9 @@
       }
     },
     "ws": {
-      "version": "7.4.6",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.1.tgz",
+      "integrity": "sha512-2c6faOUH/nhoQN6abwMloF7Iyl0ZS2E9HGtsiLrWn0zOOMWlhtDmdf/uihDt6jnuCxgtwGBNy6Onsoy2s2O2Ow==",
       "dev": true
     },
     "xdg-basedir": {
@@ -7736,12 +7681,6 @@
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
       }
-    },
-    "yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "tsc",
     "format": "prettier --write \"src/**/*.ts\"",
-    "start": "ts-node -r tsconfig-paths/register -r dotenv/config src/main.ts",
+    "start": "tsc && node -r dotenv/config dist/main.js",
     "start:debug": "nodemon --legacy-watch",
     "prestart:prod": "rimraf dist && tsc",
     "start:prod": "node dist/main.js",
@@ -52,8 +52,6 @@
     "rimraf": "^3.0.2",
     "supertest": "^6.1.3",
     "ts-jest": "^26.5.3",
-    "ts-node": "^9.1.1",
-    "tsconfig-paths": "^3.9.0",
     "tslint": "^6.1.3"
   },
   "jest": {
@@ -81,6 +79,6 @@
     "ignore": [
       "src/**/*.spec.ts"
     ],
-    "exec": "ts-node -r tsconfig-paths/register -r dotenv/config src/main.ts"
+    "exec": "tsc && node -r dotenv/config dist/main.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "format": "prettier --write \"src/**/*.ts\"",
     "start": "tsc && node -r dotenv/config dist/main.js",
     "start:debug": "nodemon --legacy-watch",
-    "start:prod": "node dist/main.js",
     "lint": "tslint -p tsconfig.json -c tslint.json",
     "lint:fix": "tslint -p tsconfig.json -c tslint.json --fix",
     "test:local": "node -r dotenv/config node_modules/.bin/jest -- local",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "rimraf dist && tsc",
     "format": "prettier --write \"src/**/*.ts\"",
-    "start": "rimraf && tsc && node -r dotenv/config dist/main.js",
+    "start": "rimraf dist && tsc && node -r dotenv/config dist/main.js",
     "start:debug": "nodemon --legacy-watch",
     "lint": "tslint -p tsconfig.json -c tslint.json",
     "lint:fix": "tslint -p tsconfig.json -c tslint.json --fix",

--- a/package.json
+++ b/package.json
@@ -10,13 +10,11 @@
     "url": "git+https://github.com/kiva/protocol.git"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "rimraf dist && tsc",
     "format": "prettier --write \"src/**/*.ts\"",
     "start": "tsc && node -r dotenv/config dist/main.js",
     "start:debug": "nodemon --legacy-watch",
-    "prestart:prod": "rimraf dist && tsc",
     "start:prod": "node dist/main.js",
-    "start:hmr": "node dist/server",
     "lint": "tslint -p tsconfig.json -c tslint.json",
     "lint:fix": "tslint -p tsconfig.json -c tslint.json --fix",
     "test:local": "node -r dotenv/config node_modules/.bin/jest -- local",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "rimraf dist && tsc",
     "format": "prettier --write \"src/**/*.ts\"",
-    "start": "tsc && node -r dotenv/config dist/main.js",
+    "start": "rimraf && tsc && node -r dotenv/config dist/main.js",
     "start:debug": "nodemon --legacy-watch",
     "lint": "tslint -p tsconfig.json -c tslint.json",
     "lint:fix": "tslint -p tsconfig.json -c tslint.json --fix",


### PR DESCRIPTION
Summary
---
* Don't run ts-node anywhere. If we're running node (and thus javascript) in production, we should be testing and developing against the same.
* Don't use cached docker resources (images, containers, etc.) when running integration tests and building the production image
* CI docker-compose shouldn't mount a local volume - it's using the production dockerfile and mounting the local volume basically ignored all the setup done by the dockerfile
* CI docker-compose shouldn't run any commands - the production dockerfile already does that