### PR TITLE
Use the integration test context in Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,6 +131,8 @@ workflows:
             tags:
               only: /.*/
       - protocol-integration-tests:
+          context:
+            - integration-test-context
           requires:
             - build-and-test
           filters: # only run for semver tagged versions


### PR DESCRIPTION
Use the integration test context for running protocol integration tests. The context contains all the relevant environment variables, so we don't need to redefine them on each individual project.

Signed-off-by: Jeff Kennedy <jeffk@kiva.org>