### PR TITLE
Use Circle CI context for CD to dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,6 +154,8 @@ workflows:
           image: kivaprotocol/protocol-gateway
           tag: << pipeline.git.tag >>,latest
       - push-to-dev:
+          context:
+            - continuous-deployment-dev
           requires:
             - docker/publish
           filters: # only run for semver tagged versions


### PR DESCRIPTION
Rather than having environment variables defined on a per-project basis, we can use a common Context which has the environment variables defined on it. This is the same way we get environment variables to run integration tests.

Signed-off-by: Jeff Kennedy <jeffk@kiva.org>